### PR TITLE
Capability to store username for further usage

### DIFF
--- a/desktop/rnkeychainmanager.cpp
+++ b/desktop/rnkeychainmanager.cpp
@@ -34,6 +34,7 @@ struct RegisterQMLMetaType {
 class RNKeychainManagerPrivate {
 public:
     Bridge* bridge = nullptr;
+    QString username;
 };
 
 RNKeychainManager::RNKeychainManager(QObject* parent) : QObject(parent), d_ptr(new RNKeychainManagerPrivate) {}
@@ -65,6 +66,7 @@ void RNKeychainManager::getGenericPasswordForOptions(QVariantList options,
 
     ReadPasswordJob rjob( keychainJobName );
     rjob.setAutoDelete( false );
+    rjob.setKey( d->username );
     QEventLoop loop;
     rjob.connect( &rjob, SIGNAL(finished(QKeychain::Job*)), &loop, SLOT(quit()) );
     rjob.start();
@@ -87,6 +89,8 @@ void RNKeychainManager::setGenericPasswordForOptions(QVariantList options,
                                                      const ModuleInterface::ListArgumentBlock &reject) {
     Q_D(RNKeychainManager);
     qDebug()<<"invoked RNKeychainManager::setGenericPasswordForOptions";
+
+    d->username = username;
 
     WritePasswordJob wjob( keychainJobName);
     wjob.setAutoDelete( false );
@@ -111,6 +115,8 @@ void RNKeychainManager::resetGenericPasswordForOptions(QVariantList options,
     Q_D(RNKeychainManager);
     qDebug()<<"invoked RNKeychainManager::resetGenericPasswordForOptions";
 
+    d->username = "";
+
     DeletePasswordJob wjob( keychainJobName);
     wjob.setAutoDelete( false );
     QEventLoop loop;
@@ -126,6 +132,14 @@ void RNKeychainManager::resetGenericPasswordForOptions(QVariantList options,
     resolve(d->bridge, QVariantList{});
 }
 
+void RNKeychainManager::setUsername(const QString &username,
+                                    const ModuleInterface::ListArgumentBlock &resolve,
+                                    const ModuleInterface::ListArgumentBlock &reject) {
+    Q_D(RNKeychainManager);
+    qDebug()<<"invoked RNKeychainManager::setUsername with username = " << username;
+    d->username = username;
 
+    resolve(d->bridge, QVariantList{QVariant(true)});
+}
 
 

--- a/desktop/rnkeychainmanager.h
+++ b/desktop/rnkeychainmanager.h
@@ -44,12 +44,12 @@ public:
     Q_INVOKABLE REACT_PROMISE void resetGenericPasswordForOptions(QVariantList options,
                                                                 const ModuleInterface::ListArgumentBlock& resolve,
                                                                 const ModuleInterface::ListArgumentBlock& reject);
+    Q_INVOKABLE REACT_PROMISE void setUsername(const QString& username,
+                                               const ModuleInterface::ListArgumentBlock& resolve,
+                                               const ModuleInterface::ListArgumentBlock& reject);
 
 private:
     QScopedPointer<RNKeychainManagerPrivate> d_ptr;
-
-    bool copyRecursively(const QString& src, const QString& dst);
-    bool removeRecursively(const QString& path);
 };
 
 #endif // RNKEYCHAINMANAGER_H

--- a/index.js
+++ b/index.js
@@ -165,6 +165,19 @@ export function setGenericPassword(
 }
 
 /**
+ * Saves the `username` for further use on get requests.
+ * @param {string} username Associated username or e-mail to be saved.
+ * @return {Promise} Resolves to `true` when successful
+ */
+export function setUsername(
+  username: string
+): Promise {
+  return RNKeychainManager.setUsername(
+    username
+  );
+}
+
+/**
  * Fetches login combination for `service`.
  * @param {string|object} serviceOrOptions Reverse domain name qualifier for the service, defaults to `bundleId` or an options object.
  * @return {Promise} Resolves to `{ service, username, password }` when successful


### PR DESCRIPTION
- On Linux both supported by qtkeychain `gnome-keyring` and `kwallet` keychains require username to be set on reading keychain service values
- On MacOS it works fine either with username set or without ( supposing to set on MacOS an username as well to not have implementation difference with Linux )
- JS API method `setUsername` introduced (seems mobile OSes don't require usernames to read values as well as macOS)

Related to https://github.com/status-im/status-react/pull/5006

P.S. The changes already verified with above PR