### PR TITLE
Added missed args to setGenericPasswordForOptions (desktop)

### DIFF
--- a/desktop/rnkeychainmanager.cpp
+++ b/desktop/rnkeychainmanager.cpp
@@ -85,6 +85,7 @@ void RNKeychainManager::getGenericPasswordForOptions(QVariantList options,
 void RNKeychainManager::setGenericPasswordForOptions(QVariantList options,
                                                      const QString &username,
                                                      const QString &password,
+                                                     const QString& minSecLevel,
                                                      const ModuleInterface::ListArgumentBlock &resolve,
                                                      const ModuleInterface::ListArgumentBlock &reject) {
     Q_D(RNKeychainManager);
@@ -141,5 +142,3 @@ void RNKeychainManager::setUsername(const QString &username,
 
     resolve(d->bridge, QVariantList{QVariant(true)});
 }
-
-

--- a/desktop/rnkeychainmanager.h
+++ b/desktop/rnkeychainmanager.h
@@ -39,6 +39,7 @@ public:
     Q_INVOKABLE REACT_PROMISE void setGenericPasswordForOptions(QVariantList options,
                                                                 const QString& username,
                                                                 const QString& password,
+                                                                const QString& minSecLevel,
                                                                 const ModuleInterface::ListArgumentBlock& resolve,
                                                                 const ModuleInterface::ListArgumentBlock& reject);
     Q_INVOKABLE REACT_PROMISE void resetGenericPasswordForOptions(QVariantList options,


### PR DESCRIPTION
Looks like absence of this fix is a reason of issue - https://github.com/status-im/status-react/issues/7348

On a fresh machine attempt to store password fails due to arguments count mismatch in a call. So `:keychain/get-encryption-key` fails and `initialize-app-db` never called.

@mandrigin, please take a look.